### PR TITLE
Fix: double scrollbar in newsletter page

### DIFF
--- a/styles/global.scss
+++ b/styles/global.scss
@@ -25,7 +25,6 @@ body {
   min-height: 100vh;
   min-height: -webkit-fill-available;
   width: 100%;
-  overflow-x: hidden;
 }
 
 [data-whatintent='mouse'] *:focus {


### PR DESCRIPTION
On page `/newsletter/success` there is double scrollbar on desktop.

<details><summary>Before</summary>
<img src="https://i.imgur.com/AhKSUq3.png" />
</details>
<details><summary>After fix</summary>
<img src="https://i.imgur.com/8jqg9Yu.png" />
</details>
