### PR TITLE
Update monorepo-typescript.mdx

### DIFF
--- a/content/posts/monorepo-typescript.mdx
+++ b/content/posts/monorepo-typescript.mdx
@@ -84,7 +84,6 @@ Jeśli już zainstalowaliśmy Lernę, to przechodzimy do jej konfiguracji, to cz
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "packages": ["packages/*"],
   "version": "1.0.0"
 }
 ```


### PR DESCRIPTION
Gdy łączymy Lerne + Yarn warto trzymać informacje o paczkach tylko w package.json, Lerna wyciągnie sobie tą informację sama z package.json. Dzieki temu mamy tylko jedno miejsce w którym przechowujemy informacje gdzie znajdują się paczki. Pozdrawiam