### PR TITLE
Bunch of fixes associated with dates in single post template.

### DIFF
--- a/components/mdx/info/Info.tsx
+++ b/components/mdx/info/Info.tsx
@@ -16,6 +16,7 @@ type InfoProps = {
 
 export const Info = ({ frontmatter }: InfoProps) => {
   const formattedDate = dayjs(frontmatter.publishedAt, 'DD-MM-YYYY').locale('pl').format('LL');
+  const reversedDateFormat = dayjs(frontmatter.publishedAt, 'DD-MM-YYYY').format('YYYY-MM-DD');
   const formattedReadingTime = polishPlurals(
     'minuta',
     'minuty',
@@ -35,7 +36,9 @@ export const Info = ({ frontmatter }: InfoProps) => {
       </li>
       <li className={styles.listItem}>
         <span className="visually-hidden">Opublikowane:</span>
-        <span className={styles.text}>{formattedDate}</span>{' '}
+        <time className={styles.text} dateTime={reversedDateFormat}>
+          {formattedDate}
+        </time>{' '}
         <div className={styles.icon}>
           <Image src="/images/calendar.png" width={35} height={35} alt="" priority />
         </div>

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,26 +1,21 @@
-import { ReactNode, useEffect, DetailedHTMLProps, HTMLAttributes } from "react";
-import { GetStaticProps, InferGetStaticPropsType } from "next";
-import { NextSeo, ArticleJsonLd } from "next-seo";
-import { MDXRemote } from "next-mdx-remote";
-import {
-  getPostBySlug,
-  getPostsPaths,
-  getAllPosts,
-  getRecommendedPosts,
-} from "../../lib/posts";
-import { Layout } from "../../components/layout/Layout";
-import { Navigation } from "../../components/navigation/Navigation";
-import { Image } from "../../components/mdx/image/Image";
-import Sparkles from "../../components/shared/components/sparkles/Sparkles";
-import { Mdx } from "../../components/mdx/Mdx";
-import { useCallback, useMemo } from "react";
-import { Heading } from "../../components/mdx/heading/Heading";
-import { useRouter } from "next/router";
-import { Newsletter } from "../../components/shared/components/newsletter/Newsletter";
-import { Highlight } from "../../components/mdx/highlight/Highlight";
-import { Code } from "../../components/mdx/code/Code";
-import { CodeWithTitle } from "../../components/mdx/codeWithTitle/CodeWithTitle";
-import getISOStringFromPublicationDate from "../../utils/getISOStringFromPublicationDate";
+import { ReactNode, useEffect, DetailedHTMLProps, HTMLAttributes } from 'react';
+import { GetStaticProps, InferGetStaticPropsType } from 'next';
+import { NextSeo, ArticleJsonLd } from 'next-seo';
+import { MDXRemote } from 'next-mdx-remote';
+import { getPostBySlug, getPostsPaths, getAllPosts, getRecommendedPosts } from '../../lib/posts';
+import { Layout } from '../../components/layout/Layout';
+import { Navigation } from '../../components/navigation/Navigation';
+import { Image } from '../../components/mdx/image/Image';
+import Sparkles from '../../components/shared/components/sparkles/Sparkles';
+import { Mdx } from '../../components/mdx/Mdx';
+import { useCallback, useMemo } from 'react';
+import { Heading } from '../../components/mdx/heading/Heading';
+import { useRouter } from 'next/router';
+import { Newsletter } from '../../components/shared/components/newsletter/Newsletter';
+import { Highlight } from '../../components/mdx/highlight/Highlight';
+import { Code } from '../../components/mdx/code/Code';
+import { CodeWithTitle } from '../../components/mdx/codeWithTitle/CodeWithTitle';
+import getISOStringFromPublicationDate from '../../utils/getISOStringFromPublicationDate';
 
 type ComponentProps = {
   readonly children: ReactNode;
@@ -81,9 +76,7 @@ const BlogPost = ({
 
   const customMdxComponents = useMemo(
     () => ({
-      pre: (
-        props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>
-      ) => {
+      pre: (props: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>) => {
         return <Code {...props} />;
       },
       h2: (props: HeadingComponentProps) => (
@@ -101,20 +94,18 @@ const BlogPost = ({
       h6: (props: HeadingComponentProps) => (
         <Heading headingTag="h6" {...getHeadingProps(props)}></Heading>
       ),
-      img: ({ alt, src }: ImageProps) => (
-        <Image src={src} alt={alt ? alt : ""} />
-      ),
+      img: ({ alt, src }: ImageProps) => <Image src={src} alt={alt ? alt : ''} />,
       Sparkles,
       Image,
       Highlight,
       Newsletter,
       CodeWithTitle,
     }),
-    []
+    [],
   );
 
   useEffect(() => {
-    window.history.scrollRestoration = "manual";
+    window.history.scrollRestoration = 'manual';
   }, []);
 
   return (
@@ -124,7 +115,7 @@ const BlogPost = ({
         description={excerpt}
         canonical={url}
         openGraph={{
-          type: "article",
+          type: 'article',
           article: {
             publishedTime: getISOStringFromPublicationDate(publishedAt),
           },
@@ -143,8 +134,8 @@ const BlogPost = ({
       />
       <ArticleJsonLd
         authorName="Olaf Sulich"
-        dateModified={publishedAt}
-        datePublished={publishedAt}
+        dateModified={getISOStringFromPublicationDate(publishedAt)}
+        datePublished={getISOStringFromPublicationDate(publishedAt)}
         description={excerpt}
         publisherLogo="/favicons/android-chrome-192x192.png"
         publisherName="Olaf Sulich"

--- a/utils/getISOStringFromPublicationDate.ts
+++ b/utils/getISOStringFromPublicationDate.ts
@@ -1,10 +1,12 @@
 const getISOStringFromPublicationDate = (date: string): string => {
-  const splittedDate = date.split("-");
+  const splittedDate = date.split('-');
 
   return new Date(
-    Number(splittedDate[2]), // Year
-    Number(splittedDate[1]) - 1, // Month
-    Number(splittedDate[0]) // Day
+    Date.UTC(
+      Number(splittedDate[2]), // Year
+      Number(splittedDate[1]) - 1, // Month
+      Number(splittedDate[0]), // Day
+    ),
   ).toISOString();
 };
 


### PR DESCRIPTION
- Added correct format ([ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)) to dates passed into `ArticleJsonLd` component.
- Time was standardized to UTC in `getISOStringFromPublicationDate.ts`.
- Replaced `span` with [`time`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) html tag - it making code more semantic.